### PR TITLE
Adding CustomerUpdateRequest that contains DefaultPaymentMethodToken

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -6,26 +6,26 @@ import (
 )
 
 type Customer struct {
-	XMLName            string                    `xml:"customer"`
-	Id                 string                    `xml:"id"`
-	FirstName          string                    `xml:"first-name"`
-	LastName           string                    `xml:"last-name"`
-	Company            string                    `xml:"company"`
-	Email              string                    `xml:"email"`
-	Phone              string                    `xml:"phone"`
-	Fax                string                    `xml:"fax"`
-	Website            string                    `xml:"website"`
-	CustomFields       customfields.CustomFields `xml:"custom-fields"`
-	CreditCard         *CreditCard               `xml:"credit-card"`
-	CreditCards        *CreditCards              `xml:"credit-cards"`
-	PayPalAccounts     *PayPalAccounts           `xml:"paypal-accounts"`
-	VenmoAccounts      *VenmoAccounts            `xml:"venmo-accounts"`
-	AndroidPayCards    *AndroidPayCards          `xml:"android-pay-cards"`
-	ApplePayCards      *ApplePayCards            `xml:"apple-pay-cards"`
-	PaymentMethodNonce string                    `xml:"payment-method-nonce"`
-	Addresses          *Addresses                `xml:"addresses"`
-	CreatedAt          *time.Time                `xml:"created-at"`
-	UpdatedAt          *time.Time                `xml:"updated-at"`
+	XMLName                   string                    `xml:"customer"`
+	Id                        string                    `xml:"id"`
+	FirstName                 string                    `xml:"first-name"`
+	LastName                  string                    `xml:"last-name"`
+	Company                   string                    `xml:"company"`
+	Email                     string                    `xml:"email"`
+	Phone                     string                    `xml:"phone"`
+	Fax                       string                    `xml:"fax"`
+	Website                   string                    `xml:"website"`
+	CustomFields              customfields.CustomFields `xml:"custom-fields"`
+	CreditCard                *CreditCard               `xml:"credit-card"`
+	CreditCards               *CreditCards              `xml:"credit-cards"`
+	PayPalAccounts            *PayPalAccounts           `xml:"paypal-accounts"`
+	VenmoAccounts             *VenmoAccounts            `xml:"venmo-accounts"`
+	AndroidPayCards           *AndroidPayCards          `xml:"android-pay-cards"`
+	ApplePayCards             *ApplePayCards            `xml:"apple-pay-cards"`
+	PaymentMethodNonce        string                    `xml:"payment-method-nonce"`
+	Addresses                 *Addresses                `xml:"addresses"`
+	CreatedAt                 *time.Time                `xml:"created-at"`
+	UpdatedAt                 *time.Time                `xml:"updated-at"`
 }
 
 // PaymentMethods returns a slice of all PaymentMethods this customer has
@@ -72,6 +72,7 @@ type CustomerRequest struct {
 	CustomFields       customfields.CustomFields `xml:"custom-fields,omitempty"`
 	CreditCard         *CreditCard               `xml:"credit-card,omitempty"`
 	PaymentMethodNonce string                    `xml:"payment-method-nonce,omitempty"`
+	DefaultPaymentMethodToken string `xml:"default_payment_method_token"`
 }
 
 type CustomerSearchResult struct {


### PR DESCRIPTION
There is a difference between a create customer and update customer request in Braintree.

The update customer requests has one more field `DefaultPaymentMethodToken`. If this field is set, it changes the default payment method of the customer.

This pull request adds that field.